### PR TITLE
Definer en default-tittel i index.html

### DIFF
--- a/apps/frontend/public/index.html
+++ b/apps/frontend/public/index.html
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Teamkatalogen</title>
   </head>
 
   <body style="margin: 0;">


### PR DESCRIPTION
Dette forhindrer et blaff av «React App» i browsertittel mens man venter på at src/components/Root.tsx er klar