### PR TITLE
Update queries from teams to console.

### DIFF
--- a/apps/backend/nais/backend-dev-gcp.yaml
+++ b/apps/backend/nais/backend-dev-gcp.yaml
@@ -60,7 +60,7 @@ spec:
           cluster: dev-gcp
       external:
         - host: slack.com
-        - host: teams.nav.cloud.nais.io
+        - host: console.nav.cloud.nais.io
         - host: behandlingskatalog-backend.intern.dev.nav.no
 
   ingresses:

--- a/apps/backend/nais/backend-prod-gcp.yaml
+++ b/apps/backend/nais/backend-prod-gcp.yaml
@@ -63,7 +63,7 @@ spec:
           cluster: prod-gcp
       external:
         - host: slack.com
-        - host: teams.nav.cloud.nais.io
+        - host: console.nav.cloud.nais.io
         - host: behandlingskatalog-backend.intern.nav.no
 
   ingresses:

--- a/apps/backend/src/main/java/no/nav/data/team/naisteam/NaisConsoleClient.java
+++ b/apps/backend/src/main/java/no/nav/data/team/naisteam/NaisConsoleClient.java
@@ -85,8 +85,10 @@ public class NaisConsoleClient {
 
     private List<NaisTeam> fetchAllNaisTeams() {
         return client.document(NaisTeam.TEAMS_QUERY)
+                .variable("limit", 1000)
+                .variable("offset", 0)
                 .execute()
-                .map(response -> response.field("teams").toEntity(new ParameterizedTypeReference<List<NaisTeam>>() {
+                .map(response -> response.field("teams.nodes").toEntity(new ParameterizedTypeReference<List<NaisTeam>>() {
                 }))
                 .block();
     }

--- a/apps/backend/src/main/java/no/nav/data/team/naisteam/NaisTeam.java
+++ b/apps/backend/src/main/java/no/nav/data/team/naisteam/NaisTeam.java
@@ -9,11 +9,16 @@ public record NaisTeam(
     @SuppressWarnings("GraphQLUnresolvedReference")
     public final static String TEAMS_QUERY = //language=graphql
             """
-            query {
-              teams {
-                slackChannel
-                purpose
-                slug
+            query ($limit: Int, $offset: Int) {
+              teams(limit: $limit, offset: $offset) {
+                nodes {
+                  slackChannel
+                  purpose
+                  slug
+                }
+                pageInfo {
+                  hasNextPage
+                }
               }
             }
             """;
@@ -21,7 +26,7 @@ public record NaisTeam(
     @SuppressWarnings("GraphQLUnresolvedReference")
     public final static String TEAM_QUERY = // language=graphql
             """
-            query($slug: String!) {
+            query($slug: Slug!) {
               team(slug: $slug) {
                 slackChannel
                 purpose

--- a/apps/backend/src/main/resources/application.yaml
+++ b/apps/backend/src/main/resources/application.yaml
@@ -88,7 +88,7 @@ client:
     console:
       auth:
         token: ${NAIS_CONSOLE_TOKEN}
-      base-url: https://teams.nav.cloud.nais.io/query
+      base-url: https://console.nav.cloud.nais.io/query
   nom:
     graphql:
       url: https://nom/graphql


### PR DESCRIPTION
There's breaking changes in the queries provided by the api, which introduces pagination.

The current implementation uses a hack to fetch all teams with one query, but adding support for pagination is recommended.

The queries themselves are tested manually, but the code is not