### PR TITLE
Add shout-out-sync-service to inbound rules of team-catalog

### DIFF
--- a/apps/backend/nais/backend-dev-gcp.yaml
+++ b/apps/backend/nais/backend-dev-gcp.yaml
@@ -53,6 +53,9 @@ spec:
         - application: portalserver
           namespace: navdig
           cluster: dev-gcp
+        - application: shout-out-sync-service
+          namespace: shout-out
+          cluster: dev-gcp
     outbound:
       rules:
         - application: nom-api

--- a/apps/backend/nais/backend-prod-gcp.yaml
+++ b/apps/backend/nais/backend-prod-gcp.yaml
@@ -56,6 +56,9 @@ spec:
         - application: portalserver
           namespace: navdig
           cluster: prod-gcp
+        - application: shout-out-sync-service
+          namespace: shout-out
+          cluster: prod-gcp
     outbound:
       rules:
         - application: nom-api


### PR DESCRIPTION
Vi i team shout out trenger data om ledere i produktområder og IT-områder