### PR TITLE
Fix outdated GraphQL query, and attempt to introduce pagination

### DIFF
--- a/apps/backend/src/main/java/no/nav/data/team/naisteam/NaisTeam.java
+++ b/apps/backend/src/main/java/no/nav/data/team/naisteam/NaisTeam.java
@@ -9,8 +9,8 @@ public record NaisTeam(
     @SuppressWarnings("GraphQLUnresolvedReference")
     public final static String TEAMS_QUERY = //language=graphql
             """
-            query ($limit: Int, $offset: Int) {
-              teams(limit: $limit, offset: $offset) {
+            query ($first: Int, $after: Cursor!) {
+              teams(first: $first, after: $after) {
                 nodes {
                   slackChannel
                   purpose
@@ -18,6 +18,7 @@ public record NaisTeam(
                 }
                 pageInfo {
                   hasNextPage
+                  endCursor
                 }
               }
             }

--- a/apps/backend/src/main/resources/application.yaml
+++ b/apps/backend/src/main/resources/application.yaml
@@ -88,7 +88,7 @@ client:
     console:
       auth:
         token: ${NAIS_CONSOLE_TOKEN}
-      base-url: https://console.nav.cloud.nais.io/query
+      base-url: https://console.nav.cloud.nais.io/graphql
   nom:
     graphql:
       url: https://nom/graphql

--- a/apps/backend/src/test/java/no/nav/data/team/WiremockExtension.java
+++ b/apps/backend/src/test/java/no/nav/data/team/WiremockExtension.java
@@ -50,7 +50,7 @@ public class WiremockExtension implements Extension, BeforeAllCallback, BeforeEa
     }
 
     private void stubCommon() {
-        getWiremock().stubFor(post("/console/query").willReturn(okJson(toJson(consoleMockResponse())))); // Stub Nais Console Team Query
+        getWiremock().stubFor(post("/console/graphql").willReturn(okJson(toJson(consoleMockResponse())))); // Stub Nais Console Team Query
 
         getWiremock().stubFor(get(urlMatching("/datacatgraph/node/out/.*")).willReturn(notFound()));
         getWiremock().stubFor(get(urlMatching("/datacatgraph/node/in/.*")).willReturn(notFound()));

--- a/apps/backend/src/test/resources/application-test.properties
+++ b/apps/backend/src/test/resources/application-test.properties
@@ -3,7 +3,7 @@ spring.kafka.security.protocol=PLAINTEXT
 spring.main.allow-bean-definition-overriding=true
 spring.main.lazy-initialization=true
 
-client.nais.console.base-url=http://localhost:${wiremock.server.port:8080}/console/query
+client.nais.console.base-url=http://localhost:${wiremock.server.port:8080}/console/graphql
 client.process-cat.base-url=http://localhost:${wiremock.server.port:8080}/processcat
 client.nom.graphql.url=http://localhost:${wiremock.server.port:8080}/nomgraphql
 team-catalog.envlevel=primary


### PR DESCRIPTION
NAIS API just released v1, and as a result of that the queries in "Teamkatalogen" must be updated.

v1 of NAIS API implements the [Cursor Connections Specification](https://github.com/nais/api/blob/main/docs/graphql_practices.md#pagination) instead of the limit / offset based pagination we previously had.

Basically we fetch a page of teams, and the `pageInfo` object holds information about how to continue to fetch more.

The query for a single team has not changed in v1, so there was no need to update that.

Also, the GraphQL endpoint has been changed from "/query" to "/graphql".

Take into consideration that Java is **not** a language that I use on a daily basis (this is probably the first time I have written Java in over 20 years), so feel free to make any change you deem necessary.

More info:

- https://github.com/nais/api/blob/main/docs/graphql_practices.md#pagination
- https://relay.dev/graphql/connections.htm
