### PR TITLE
Sorter roleOptions i EditMembersModal alfabetisk

### DIFF
--- a/apps/frontend/src/components/team/EditMembersModal.tsx
+++ b/apps/frontend/src/components/team/EditMembersModal.tsx
@@ -191,10 +191,12 @@ function MemberForm({
     },
   });
 
-  const roleOptions = Object.values(TeamRole).map((role) => ({
-    value: role,
-    label: intl[role],
-  }));
+  const roleOptions = Object.values(TeamRole)
+    .map((role) => ({
+      value: role,
+      label: intl[role],
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   const onSubmitUpdatedMember = methods.handleSubmit((submittedValues) => {
     const updatedMember = member


### PR DESCRIPTION
Synes det hadde vært lettere å finne rollene hvis de var sortert alfabetisk. Prøver meg på en PR som dere bare får stenge hvis det er usortert for en grunn.